### PR TITLE
users can login with email/username and password

### DIFF
--- a/src/resolvers/UserResolver.ts
+++ b/src/resolvers/UserResolver.ts
@@ -38,7 +38,10 @@ export class UserResolver {
             };
 
             return jwt.sign(
-                await Utils.generateJsWebToken(user.id), 
+                {
+                    ...await Utils.generateJsWebToken(user.id),
+                    type: "user"
+                }, 
                 Utils.SECRET_KEY, 
                 { expiresIn: "2w" }
             );
@@ -54,7 +57,10 @@ export class UserResolver {
         if ( user ) {
             if ( await bcrypt.compare(password, user.password) ) {
                 return jwt.sign(
-                    await Utils.generateJsWebToken(user.id),
+                    {
+                        ...await Utils.generateJsWebToken(user.id),
+                        type: "user"
+                    },
                     Utils.SECRET_KEY,
                     { expiresIn: "2w" }
                 );


### PR DESCRIPTION
## What it does
> It allows users to login in using their email/username and password

## What issue it fixes
> It closes issue #22 where users couldn't login but now they can.

## SIDE NOTE
> Although this fixes issue #22 it does not do it exactly like the issue asks:
> - it uses ```email``` and ```username``` rather than just ```email``` to verify credentials. 
> - It also does not create ```UserLogIn``` in the ```AuthenticateResolver``` instead ```UserLogIn``` is created in ```UserResolver```.
> - It requires to parameter from the GraphQl end point: ```username``` ( can be email or actual username ) is a string. And ```password``` ( user password ) is a string.