### PR TITLE
foodTrucks can login with email/truckName & password

### DIFF
--- a/src/resolvers/FoodTruckResolver.ts
+++ b/src/resolvers/FoodTruckResolver.ts
@@ -37,10 +37,35 @@ export class FoodTruckResolver {
             }
 
             return jwt.sign(
-                await Utils.generateJsWebToken(foodTruck.id),
+                {
+                    ...await Utils.generateJsWebToken(foodTruck.id),
+                    type: "foodTruck"
+                },
                 Utils.SECRET_KEY,
                 { expiresIn: "2w" }
             )
         }
+    }
+
+    @Mutation( returns => String ) 
+    async FoodTruckLogIn( @Arg("truckName") truckName: string, @Arg("password") password: string ) {
+        let foodTruck = await models.FoodTrucks.findOne({ where: { truckName } });
+
+        if ( !foodTruck ) foodTruck = await models.FoodTrucks.findOne({ where: { email: truckName }}) // Just incase they are using there email
+
+        if ( foodTruck ) {
+            if ( await bcrypt.compare(password, foodTruck.password) ) {
+                return jwt.sign(
+                    {
+                        ...await Utils.generateJsWebToken(foodTruck.id),
+                        type: "foodTruck"
+                    },
+                    Utils.SECRET_KEY,
+                    { expiresIn: "2w" }
+                );
+            }
+        }
+
+        throw new Utils.CustomError("Invalid credentials. Please try again")
     }
 }


### PR DESCRIPTION
## What it does
> It allows foodtrucks to login in using their email/truckNameand password

## What issue it fixes
> It closes issue #24 where users couldn't login but now they can.

## SIDE NOTE
> Although this fixes issue #24 it does not do it exactly like the issue asks:
> - it uses ```email``` and ```truckName``` rather than just ```email``` to verify credentials. 
> - It also does not create ```FoodTruckLogIn``` in the ```AuthenticateResolver``` instead ```FoodTruckLogIn``` is created in ```FoodTruckResolver```.
> - It requires to parameter from the GraphQl end point: ```truckName``` ( can be email or actual truckName) is a string. And ```password``` ( user password ) is a string.