### PR TITLE
Add event type, monetization, and public fields

### DIFF
--- a/src/migration/events/createEvent.ts
+++ b/src/migration/events/createEvent.ts
@@ -5,6 +5,27 @@ export const createEvent = async ( orgId: string, event: typeof migrationData.ev
     const randomDate = Date.now() + Math.floor( Math.random() * 1e10 ); // Future timestamp
     const endDate = randomDate + Math.floor( Math.random() * 1e6 ); // End after a random date;
 
+    let eventType: models.EventType;
+    let is_monetized: boolean;
+    let is_public = Math.floor( Math.random() * 2 ) === 0 ? true : false;;
+
+    let randomType = Math.floor( Math.random() * 2 );
+
+    switch ( randomType ) {
+        case 0:
+            eventType = models.EventType.PAID_TICKET;
+            is_monetized = true;
+            break;
+        case 1:
+            eventType = models.EventType.CYOP;
+            is_monetized = true;
+            break;
+        default:
+            eventType = models.EventType.REGISTRATION;
+            is_monetized = Math.floor( Math.random() * 2 ) === 0 ? true : false;
+            break;
+    }
+
     let e = await models.Events.create({
         title: event.title,
         description: event.description.join('\n\n'),
@@ -14,6 +35,10 @@ export const createEvent = async ( orgId: string, event: typeof migrationData.ev
         banner: event.banner,
         visible: true,
         location: event.location,
+
+        type: eventType,
+        is_monetized,
+        is_public
     }).save();
 
     console.log(`\n\t\tCreated event: ${e.id}`);

--- a/src/models/types/organizer/Event.ts
+++ b/src/models/types/organizer/Event.ts
@@ -1,5 +1,19 @@
 import { ObjectType, InputType, Field, ID } from "type-graphql";
 import { Location } from "../Location";
+import { EventType } from "../../organizers";
+
+@InputType()
+export class CreateEventInput {
+    @Field() title: string;
+
+    @Field() description: string;
+
+    @Field( () => EventType ) type: EventType;
+
+    @Field() is_public: boolean;
+
+    @Field() is_monetized: boolean;
+}
 
 @ObjectType()
 export class EventOrganizerResponse {

--- a/src/resolvers/OrganizerResolver.ts
+++ b/src/resolvers/OrganizerResolver.ts
@@ -538,17 +538,20 @@ export class OrganizerResolver {
     }
 
     @Mutation(() => models.Events)
-    async createEvent(@Arg('token') token: string, @Arg('title') title: string, @Arg('description') description: string) {
+    async createEvent(@Arg('token') token: string, @Arg('args', () => models.CreateEventInput ) args: models.CreateEventInput ) {
         let org = await Utils.getOrgFromOrgOrMemberJsWebToken(token, [], true);
 
         let event = await models.Events.create({
-            title,
-            description,
+            title: args.title,
+            description: args.description,
+            type: args.type,
+            is_public: args.is_public,
+            is_monetized: args.is_monetized,
             banner: "",
             organizer: { id: org.id }
         }).save();
 
-        let stripeEvent = await stripeHandler.createEvent(org.stripeConnectId, org.id, event.id, title);
+        let stripeEvent = await stripeHandler.createEvent(org.stripeConnectId, org.id, event.id, args.title, { ...args });
 
         event.productId = stripeEvent.id;
 


### PR DESCRIPTION
Introduces 'type', 'is_monetized', and 'is_public' fields to event creation logic, input types, and resolver. This enables more flexible event configuration and supports new event types and monetization options.