### PR TITLE
Refactor event ticketing for CYOP and registration types

### DIFF
--- a/src/models/organizers/events/Events.ts
+++ b/src/models/organizers/events/Events.ts
@@ -52,12 +52,12 @@ export class Events extends BaseEntity {
     is_public: boolean; // If this event is public or private, private events are only accessible via direct link, meaning this event won't show up on app, and it won't be searchable
 
     @Field()
-    @Column({ default: 0 })
-    minPrice: number; // Only in use in CYOP events;
+    @Column()
+    cyop_id: string; // ID for the choose your own price ticket
 
     @Field()
-    @Column({ default: 0 })
-    maxPrice: number; // Only in use in CYOP events;
+    @Column()
+    registration_id: string; // ID for the registration ticket
 
     @Field()
     @Column({ default: "" })
@@ -74,10 +74,6 @@ export class Events extends BaseEntity {
     @Field()
     @Column({ default: '' })
     location: string;
-
-    @Field()
-    @Column({ default: 'limited' })
-    ticketType: 'infinite' | 'limited';
 
     @Field()
     @Column({ default: "America/New_York" })

--- a/src/models/organizers/events/eventTickets.ts
+++ b/src/models/organizers/events/eventTickets.ts
@@ -24,8 +24,16 @@ export class EventTickets extends BaseEntity {
     priceId: string;
 
     @Field()
-    @Column({ type: 'float' })
+    @Column({ type: 'float', default: 0 })
     amount: number;
+
+    @Field()
+    @Column({ type: 'float', default: 0 })
+    minPrice: number;
+
+    @Field()
+    @Column({ type: 'float', default: 0 })
+    maxPrice: number;
 
     @Field()
     @Column({ default: 'usd' })

--- a/src/models/types/organizer/Event.ts
+++ b/src/models/types/organizer/Event.ts
@@ -266,8 +266,6 @@ export class EventsPage {
 
     @Field() endEventDate: Date;
 
-    @Field() ticketType: string;
-
     @Field() ticketAvailable: number;
 
     @Field( () => [ PhotoGallery ] ) photoGallery: PhotoGallery[];

--- a/src/resolvers/OrganizerResolver.ts
+++ b/src/resolvers/OrganizerResolver.ts
@@ -555,6 +555,51 @@ export class OrganizerResolver {
 
         event.productId = stripeEvent.id;
 
+        let eventTicket: models.EventTickets;
+        let amount = 0;
+
+        if ( event.type === models.EventType.CYOP ) {
+
+            eventTicket = await models.EventTickets.create({
+                title: "Choose Your Own Price",
+                description: "Donation Ticket",
+                event,
+                minPrice: 0,
+                maxPrice: 0,
+                currency: 'usd'
+            }).save();
+        }else if ( event.type === models.EventType.REGISTRATION ) {
+            eventTicket = await models.EventTickets.create({
+                title: "General Admission",
+                description: "General Admission Ticket",
+                event,
+                amount: 0,
+                currency: 'usd'
+            }).save();
+        }
+
+        if ( event.type === models.EventType.CYOP || event.type === models.EventType.REGISTRATION ) {
+            try {
+                let stripeTicket = await stripeHandler.createEventPrice(org.stripeConnectId, org.id, event.id, event.productId, amount, 'usd');
+    
+                eventTicket!.priceId = stripeTicket.id;
+    
+                await eventTicket!.save();
+
+                event.type === models.EventType.CYOP ? 
+                    event.cyop_id = eventTicket!.id : 
+                    event.registration_id = eventTicket!.id;
+
+            } catch (err) {
+    
+                console.log(err);
+    
+                await eventTicket!.remove(); // want to self clean database
+    
+                return new Utils.CustomError("Problem creating event ticket")
+            }
+        }
+
         await event.save();
 
         return event;
@@ -572,10 +617,19 @@ export class OrganizerResolver {
             title: parentEvent.title,
             description: parentEvent.description,
             banner: parentEvent.banner,
+
             latitude: parentEvent.latitude,
             longitude: parentEvent.longitude,
+
             location: parentEvent.location,
-            ticketType: parentEvent.ticketType,
+
+            photoGallery: parentEvent.photoGallery,
+            prices: parentEvent.prices,
+
+            type: parentEvent.type,
+            is_public: parentEvent.is_public,
+            is_monetized: parentEvent.is_monetized,
+
             organizer: { id: org.id },
             // If event alread has a parent we will use that parent, else we will make that event the parent.
             parent: { id: parentEvent.parent ? parentEvent.parent.id : parentEvent.id },
@@ -782,7 +836,7 @@ export class OrganizerResolver {
 
         let event = await models.Events.findOne({ where: { id: eventId, organizer: { id: org.id } } });
 
-        if (!event) return new Utils.CustomError("Event does not exist");
+        if (!event || event === null) return new Utils.CustomError("Event does not exist");
 
         let tickets = await models.EventTickets.find({ where: { event: { id: eventId } } });
 
@@ -834,7 +888,9 @@ export class OrganizerResolver {
                     },
                     tickets: cart.tickets.map(ticket => ({
                         id: ticket.id,
-                        title: ticket.eventTicket.title,
+                        title: ticket.eventTicket ? ticket.eventTicket.title : 
+                            event?.type
+                        ,
                         description: ticket.eventTicket.description,
                         quantity: ticket.quantity,
                         price: ticket.eventTicket.amount


### PR DESCRIPTION
Moved minPrice and maxPrice fields from Events to EventTickets and added cyop_id and registration_id to Events for better ticket type management. Updated resolvers and Stripe client secret logic to support choose-your-own-price (CYOP) and registration event types, including new mutations and payment intent handling. Removed ticketType from Events and related type definitions, and improved OrganizerResolver event creation and duplication logic for new event types.